### PR TITLE
fix(rtl): cleanup Verilog lint warnings (Verilator/Yosys)

### DIFF
--- a/Src/Control.v
+++ b/Src/Control.v
@@ -2,8 +2,6 @@ module Control
 #( 
     parameter NB_OP = 6
 )(
-    input wire clk,
-    input wire i_reset,
     input wire [NB_OP-1:0] i_opcode       , //[31:26] instruction
     input wire [NB_OP-1:0] i_funct        , // for R-type [5:0] field
 
@@ -301,6 +299,12 @@ module Control
                 r_branch    = 1'b0 ;
                 r_jump      = 1'b1 ;
                 r_aluOP     = 2'b00; // X: unknown o don't care
+            end
+
+             // *** add this ***
+            default: begin
+            // cover opcodes not listed (e.g. REGIMM = 6'b000001, etc.)
+            // keep defaults (no jump/branch, no mem, no writeback)
             end
 
         endcase

--- a/Src/EX_Stage.v
+++ b/Src/EX_Stage.v
@@ -17,7 +17,6 @@ module EX_Stage
     //ctrl unit
     input wire                  i_regDst                        , 
     input wire                  i_mem2reg                       , 
-    input wire                  i_memRead                       , 
     input wire                  i_memWrite                      , 
     input wire                  i_immediate_flag                , 
     input wire                  i_regWrite                      ,
@@ -68,7 +67,6 @@ module EX_Stage
 
     reg  [5:0]           opcode                                  ;
     reg  signed [NB_DATA-1:0]   alu_data_A, alu_data_B, data4Mem ; //data4Mem_aux
-    reg  [1:0]           aluOP                                   ;
     wire [NB_DATA-1:0]   alu_result                              ;
 
     //! state machine for alu

--- a/Src/IDEX.v
+++ b/Src/IDEX.v
@@ -33,6 +33,8 @@ module IDEX (
     localparam [5:0] R_TYPE   = 6'b000000;
     localparam [5:0] JARL_TYPE = 6'b011111;
 
+    (* keep *) wire _unused_idex_instr_bits = |{ i_instruction[31:11], i_instruction[5:0] };
+
     always @(posedge clk or negedge i_reset) begin
         if (!i_reset) begin
             o_reg_DA         <= 32'b0;

--- a/Src/ID_Stage.v
+++ b/Src/ID_Stage.v
@@ -7,7 +7,6 @@ module ID_Stage
     input wire                 i_reset          ,
     input wire [NB_DATA-1:0]   i_instruction    ,
     input wire [NB_DATA-1:0]   i_pc      ,
-    input wire                 i_we_wb          ,
     input wire                 i_we             ,
     input wire [NB_ADDR-1:0]   i_wr_addr        ,
     input wire [NB_DATA-1:0]   i_wr_data_WB     ,
@@ -106,8 +105,6 @@ module ID_Stage
     Control #()                                                            
     ctrl                                                           
     (                                                           
-        .clk        (clk        )               ,
-        .i_reset    (i_reset    )               ,
         .i_opcode   (opcode     )               ,
         .i_funct    (func       )               ,
 
@@ -186,6 +183,11 @@ module ID_Stage
             // Unconditional jump (J)
             o_jump      = 1'b1;
             o_addr2jump = {i_pc[NB_DATA-1:NB_DATA-4], i_instruction[25:0], 2'b00}; // Absolute jump address
+        end
+
+         default: begin
+            // cover opcodes not listed (e.g. REGIMM = 6'b000001, etc.)
+            // no jump: defaults are preserved
         end
 
         endcase

--- a/Src/IF_Stage.v
+++ b/Src/IF_Stage.v
@@ -2,15 +2,15 @@ module IF_Stage
 (
     input wire          clk,
     input wire          i_reset,   
-    input wire          i_jump,          //! 1 = jump asserted | 0 = normal PC increment
-    input wire          i_we,            //! Write enable para inicializar memoria
-    input wire [31:0]   i_jump_address,     //! Dirección a saltar
-    input wire [31:0]   i_inst_data,    //! Dato a escribir si i_we está en 1
-    input wire [31:0]   i_instruction_addr,     //! Dirección para escribir instrucción
-    input wire          i_halt,          //! Halt del pipeline
-    input wire          i_stall,         //! Stall del pipeline
-    output wire [31:0]  o_instruction,   //! Instrucción registrada (salida del IFID)
-    output wire [31:0]  o_pc       //! Program counter
+    input wire          i_jump,             //! 1 = jump asserted | 0 = normal PC increment
+    input wire          i_we,               //! Write enable to initialize memory
+    input wire [31:0]   i_jump_address,     //! Address to jump
+    input wire [31:0]   i_inst_data,        //! Data to write if i_we is 1
+    input wire [7:0]    i_instruction_addr, //! Address to write instruction
+    input wire          i_halt,             //! Pipeline halt
+    input wire          i_stall,            //! Pipeline stall
+    output wire [31:0]  o_instruction,      //! Registered instruction (IFID output)
+    output wire [31:0]  o_pc                //! Program counter
 );
 
     wire [31:0] instruction_data;
@@ -18,31 +18,31 @@ module IF_Stage
 
     //! PC module
     PC programcounter (
-        .clk        (clk),
-        .i_reset    (i_reset),
-        .i_jump_address(i_jump_address),
-        .i_jump     (i_jump),
-        .o_pc (o_pc),
-        .i_halt     (i_halt),
-        .i_stall    (i_stall)
+        .clk            (clk),
+        .i_reset        (i_reset),
+        .i_jump_address (i_jump_address),
+        .i_jump         (i_jump),
+        .o_pc           (o_pc),
+        .i_halt         (i_halt),
+        .i_stall        (i_stall)
     );
 
-    //! RAM de instrucciones
+    //! Instruction RAM
     RAM #(
         .NB_DATA(32),
         .NB_ADDR(8)
     ) InstructionMemory (
-        .clk              (clk),
-        .i_write_enable   (i_we),
-        .i_data           (i_inst_data),
-        .i_addr_w         (instruction_addr),
-        .o_data           (instruction_data)
+        .clk            (clk),
+        .i_write_enable (i_we),
+        .i_data         (i_inst_data),
+        .i_addr_w       (instruction_addr),
+        .o_data         (instruction_data)
     );
 
-    //! Selección de dirección: para escribir (i_we) o para fetch
-    assign instruction_addr = i_we ? i_instruction_addr[7:0] : o_pc[7:0];
+    //! Address selection: for writing (i_we) or for fetch
+    assign instruction_addr = i_we ? i_instruction_addr : o_pc[7:0];
 
-    //! IF/ID register instanciado internamente
+    //! IF/ID register instantiated internally
     IFID ifid_sreg (
         .clk           (clk),
         .i_reset       (i_reset),

--- a/Src/MIPS.v
+++ b/Src/MIPS.v
@@ -5,9 +5,7 @@ module MIPS
     input wire          i_we_IF             ,
     input wire [31:0]   i_instruction_data  ,
     input wire          i_step              , 
-    input wire [31:0]   i_instruction_addr  ,
-    // IF
-
+    input wire [7:0]   i_instruction_addr   ,
     output  [143:0] o_segment_registers_ID_EX,
     output  [31:0]  o_segment_registers_EX_MEM,
     output  [47:0]  o_segment_registers_MEM_WB,
@@ -51,10 +49,10 @@ module MIPS
         
     parameter NB_FW = 2;
     wire [NB_FW-1 : 0] fwB_FU2EX, fwA_FU2EX;
-    wire [1:0] aluSrcEX2MEM ,  widthEX2MEM  ;
-    wire    jumpEX2MEM, branchEX2MEM, regDstEX2MEM, mem2RegEX2MEM   , 
-            memWriteEX2MEM, immediate_flagEX2MEM, sign_flagEX2MEM   , 
-            regWriteEX2MEM, memReadEX2MEM                           ;
+    wire [1:0]   widthEX2MEM  ;
+    wire    mem2RegEX2MEM   , 
+            memWriteEX2MEM,  sign_flagEX2MEM   , 
+            regWriteEX2MEM                           ;
     wire [4:0] write_regEX2MEM;
     wire [NB_DATA-1:0] data4MemEX2MEM, resultALUEX2MEM;
     wire [NB_DATA-1:0] reg_readMEM2WB, resultALUMEM2WB;
@@ -68,9 +66,7 @@ module MIPS
     wire [4:0] rsIF2ID;
     wire [4:0] rtIF2ID;
     wire [1:0] jumpType;
-    wire [31:0] inst_addr_from_interface;
     wire [4 :0] aux_rdEX;
-    assign inst_addr_from_interface = i_instruction_addr;
     assign aux_rdEX = regDstID2EX ? rtID2EX : rdID2EX;
     assign o_pcounterIF2ID_LSB = pcounterIF2ID[15:0];
 
@@ -106,7 +102,7 @@ module MIPS
         .i_we           (i_we_IF),  
         .i_jump_address (addr2jumpID2IF),  
         .i_inst_data   (i_instruction_data ),  
-        .i_instruction_addr    (inst_addr_from_interface),
+        .i_instruction_addr    (i_instruction_addr),
         .i_halt         (haltIF),
         .i_stall        (stall), 
         .o_instruction  (instructionIF2ID),
@@ -124,7 +120,6 @@ module MIPS
         .i_reset                  (i_reset),
         .i_instruction            (instructionIF2ID ),
         .i_pc                     (pcounterIF2ID ),
-        .i_we_wb                  ( ),
         .i_we                     (regWriteWB2ID ),
         .i_wr_addr                (reg2writeWB2ID),
         .i_wr_data_WB             (write_dataWB2ID),
@@ -173,7 +168,6 @@ module MIPS
         .i_func                          (funcID2EX),
         .i_regDst                        (regDstID2EX ), 
         .i_mem2reg                       (mem2RegID2EX), 
-        .i_memRead                       (memReadID2EX), 
         .i_memWrite                      (memWriteID2EX), 
         .i_immediate_flag                (immediate_flagID2EX), 
         .i_regWrite                      (regWriteID2EX),
@@ -211,8 +205,8 @@ module MIPS
     );
 
     MEM_Stage  #(
-        .NB_DATA(),
-        .NB_ADDR()
+        .NB_DATA(32),
+        .NB_ADDR(8)
     ) MEM_inst (
         .clk                             (clk),
         .i_reset                         (i_reset),

--- a/Src/top.v
+++ b/Src/top.v
@@ -38,7 +38,6 @@ module top (
     // Single system clock: use input directly
     wire clk = clk_100MHz;
 
-    wire tick;  //! Tick signal for the UART
     wire [NB_DATA_8-1:0] data_Rx2Interface;
     wire rxDone;
     wire [NB_DATA_8-1:0] data_Interface2Tx;
@@ -50,39 +49,7 @@ module top (
     wire halt;
     wire start;
     wire i_end; //! End of program — TO VERIFY HOW THE PIPELINE FINISHES
-
-    //ID_EX
-    wire [NB_DATA_32 -1 : 0] reg_DA      ; //! Register A
-    wire [NB_DATA_32 -1 : 0] reg_DB      ; //! Register B
-    wire [NB_6  -1 : 0]      opcode      ; //! Opcode
-    wire [NB_5  -1 : 0]      rs          ; //! rs
-    wire [NB_5  -1 : 0]      rt          ; //! rt
-    wire [NB_5  -1 : 0]      rd          ; //! rd
-    wire [NB_5  -1 : 0]      shamt       ; //! shamt
-    wire [NB_6  -1 : 0]      funct       ; //! funct
-    wire [NB_16 -1 : 0]      immediate   ; //! immediate
-    wire [NB_DATA_32 -1 : 0] addr2jump   ; //! jump address
-    wire [NB_DATA_32 -1 : 0] ALUresult   ; //! ALU result    
-    wire [NB_DATA_32 -1 : 0] data2mem    ; //! Memory data
-    wire [NB_DATA_8-1: 0]    dataAddr    ; //! Memory address 
-    wire memWriteDebug      ;    
-    wire [NB_DATA_32  -1: 0] write_dataWB2ID    ; //! Write data
-    wire [NB_5   -1: 0]      reg2writeWB2ID     ; //! Register to write
-    wire write_enable       ; //! Write enable              
-    wire jump        ; //! Jump
-    wire branch      ; //! Branch
-    wire regDst      ; //! RegDst
-    wire mem2Reg     ; //! MemToReg
-    wire memRead     ; //! MemRead
-    wire memWrite    ; //! MemWrite
-    wire inmediate_flag     ; //! Immediate flag
-    wire sign_flag   ; //! Sign flag
-    wire regWrite    ; //! RegWrite
-    wire [ 1 : 0]      aluSrc      ; //! ALU source
-    wire [ 1 : 0]      width       ; //! ALU operation width
-    wire [ 1 : 0]      aluOp       ; //! ALU operation    
-    wire [ 1 : 0]      fwA         ; //! Forward A
-    wire [ 1 : 0]      fwB         ; //! Forward B
+    
 
     wire [NB_ID_EX   -1 : 0] segment_registers_ID_EX    ; 
     wire [NB_EX_MEM  -1 : 0] segment_registers_EX_MEM   ;
@@ -93,6 +60,9 @@ module top (
     // Removed clk_wiz_0 — all logic uses 'clk' directly
 
     wire [31:0] inst_addr_from_interface;
+
+    wire _unused_inst_addr_hi_top = |inst_addr_from_interface[31:8];   
+
     debug_unit #(
         .NB_DATA(NB_DATA_8),
         .NB_STOP(NB_STOP),
@@ -133,7 +103,7 @@ module top (
         .i_we_IF                       (we),    // This receives the interface's `o_valid` signal
         .i_instruction_data            (instruction), // Instruction from interface
         .i_step                        (aux_halt), // This receives the interface's `o_step` signal
-        .i_instruction_addr            (inst_addr_from_interface),
+        .i_instruction_addr            (inst_addr_from_interface[7:0]),
         .o_end                         (i_end),
         .o_segment_registers_ID_EX     (segment_registers_ID_EX),
         .o_segment_registers_EX_MEM    (segment_registers_EX_MEM),


### PR DESCRIPTION
# Fix Verilog Lint Warnings (Verilator/Yosys)

## Summary
This PR addresses multiple syntax and lint warnings raised by **Verilator** and **Yosys** during simulation and synthesis.  
The goal is to clean up the RTL code without introducing functional changes.

## Changes
- Removed **unused signals** and ports (`reg_DA`, `reg_DB`, `opcode`, etc.).
- Fixed **empty pin connections** (e.g., `.i_we_wb()`).
- Cleaned up **undriven wires** in `top.v` and `MIPS.v`.
- Adjusted **incomplete case statements** in `ID_Stage.v` and `Control.v`.
- General Verilog syntax cleanup to achieve a **lint-clean build**.

## Motivation
- Reduce noise from lint warnings in Verilator/Yosys.
- Improve readability and maintainability of RTL sources.
- Ensure a cleaner base for future functional changes.

## Validation
- Ran `verilator --lint-only` and `yosys -Q` → warnings reduced/removed.
- No functional changes introduced (only cleanup).

## Related
- Branch: `fix/verilog-lint-warnings`
- Tools: Verilator, Yosys